### PR TITLE
fix: correct release detection logic in release-pr workflow

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -41,10 +41,11 @@ jobs:
         id: check
         run: |
           # Run semantic-release in dry-run mode to check if release is needed
-          if uv run semantic-release version --no-commit --no-tag --no-push --print 2>/dev/null | grep -q "Bumping version"; then
-            echo "release_needed=true" >> $GITHUB_OUTPUT
-          else
+          OUTPUT=$(uv run semantic-release version --no-commit --no-tag --no-push --print 2>&1)
+          if echo "$OUTPUT" | grep -iq "no release will be made"; then
             echo "release_needed=false" >> $GITHUB_OUTPUT
+          else
+            echo "release_needed=true" >> $GITHUB_OUTPUT
           fi
 
       - name: Create release branch and PR

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -40,6 +40,7 @@ jobs:
       - name: Check if release needed
         id: check
         run: |
+          set -e
           # Run semantic-release in dry-run mode to check if release is needed
           OUTPUT=$(uv run semantic-release version --no-commit --no-tag --no-push --print 2>&1)
           if echo "$OUTPUT" | grep -iq "no release will be made"; then


### PR DESCRIPTION
## Problem

The release-pr workflow was failing to detect when a release was needed because it was checking for 'Bumping version' in the semantic-release output, but that text never appears.

## Root Cause

When using the `--print` flag, semantic-release outputs:
- **When release needed**: Just the version number (e.g., `1.0.0`)
- **When no release needed**: `No release will be made, X.Y.Z has already been released!`

The workflow was checking for 'Bumping version' which never appears in either case.

## Solution

Changed the detection logic to:
1. Capture the full output from semantic-release
2. Check if output contains 'no release will be made' (case-insensitive)
3. If found → no release needed
4. If not found → release needed

## Testing

Tested locally with:
- No git tags (should detect release needed) ✅
- With matching tag (should detect no release needed) ✅

## Related

This fixes the issue where the workflow was skipping PR creation even when there were `fix:` or `feat:` commits that should trigger a release.