### PR TITLE
fix: run semantic-release on main branch before creating release branch

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -54,6 +54,8 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          set -e
+
           # Get the new version from semantic-release output
           NEW_VERSION=$(uv run semantic-release version --no-commit --no-tag --no-push --print 2>/dev/null | head -1)
 
@@ -66,18 +68,14 @@ jobs:
 
           BRANCH_NAME="release-v${NEW_VERSION}"
 
-          # Check if branch already exists
-          if git ls-remote --heads origin "$BRANCH_NAME" | grep -q "$BRANCH_NAME"; then
-            echo "Release branch $BRANCH_NAME already exists"
-            git fetch origin "$BRANCH_NAME"
-            git checkout "$BRANCH_NAME"
-            git reset --hard origin/main
-          else
-            git checkout -b "$BRANCH_NAME"
-          fi
-
-          # Run semantic-release to update versions and changelog
+          # Run semantic-release on main to create the version bump commits
           uv run semantic-release version --no-push --no-tag
+
+          # Create release branch from the current state (with version bump commits)
+          git branch -f "$BRANCH_NAME"
+
+          # Reset main back to origin/main (undo local commits on main)
+          git reset --hard origin/main
 
           # Push the release branch
           git push -f origin "$BRANCH_NAME"


### PR DESCRIPTION
## Problem

The release-pr workflow was creating the release branch and then running semantic-release on that branch. This caused semantic-release to refuse making a release with the error:

```
branch 'release-v1.0.0' isn't in any release groups; no release will be made
```

This resulted in an empty release branch with no commits, causing the PR creation to fail with:

```
No commits between main and release-v1.0.0
```

## Root Cause

semantic-release is configured to only work on the `main` branch (via `[tool.semantic_release.branches.main]` in pyproject.toml). When the workflow checked out the release branch before running semantic-release, it saw it wasn't on `main` and refused to create a release.

## Solution

Changed the workflow execution order:

**Before:**
1. Checkout/create release branch
2. Run semantic-release (fails because not on main)
3. Try to push empty branch
4. Try to create PR (fails because no commits)

**After:**
1. Run semantic-release on main (creates version bump commits)
2. Create release branch pointing to current HEAD
3. Reset main back to origin/main (keeps commits in release branch only)
4. Push release branch with commits
5. Create PR successfully

## Testing

Workflow logic changes only - will be tested when merged and workflow runs on main.

## Related

- Fixes the workflow failure shown in the logs where PR creation failed due to no commits between branches
- Complements PR #11 which fixed the release detection logic