### PR TITLE
fix: disable build/upload in semantic-release config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,9 +94,9 @@ dev = [
 version_toml = ["pyproject.toml:project.version"]
 version_variables = ["src/mcp_pytest_runner/__init__.py:__version__"]
 branch = "main"
-upload_to_pypi = true
-upload_to_release = true
-build_command = "pip install build && python -m build"
+# Build and upload handled by release-publish.yml workflow after PR merge
+upload_to_pypi = false
+upload_to_release = false
 commit_parser = "angular"
 major_on_zero = false
 tag_format = "v{version}"


### PR DESCRIPTION
## Problem

The release-pr workflow was failing during the build phase with:

```
ERROR: Command 'pip install build && python -m build' returned non-zero exit status 1.
```

This happened because semantic-release was configured to build and upload during the `version` command, but:
1. The build command was incompatible with our uv-based workflow
2. We don't want to build/upload during PR creation - only after PR merge

## Root Cause

The semantic-release config had:
```toml
upload_to_pypi = true
upload_to_release = true
build_command = "pip install build && python -m build"
```

This caused semantic-release to attempt building and uploading during the version bump phase, which is wrong for our PR-based workflow.

## Solution

Changed semantic-release config to only handle version bumping and changelog:
```toml
upload_to_pypi = false
upload_to_release = false
# Removed build_command
```

The release-publish.yml workflow handles all building and PyPI publishing after the release PR is merged.

## Workflow Separation

**release-pr.yml** (runs on push to main):
- ✅ Detect if release needed
- ✅ Update versions (pyproject.toml, __init__.py)
- ✅ Update CHANGELOG.md
- ✅ Create PR

**release-publish.yml** (runs on PR merge):
- ✅ Build package with `uv build`
- ✅ Publish to PyPI
- ✅ Create GitHub release
- ✅ Create git tag

## Related

- Builds on PR #12 which fixed the branch execution order
- Complements PR #11 which fixed release detection logic