### PR TITLE
fix: add initial CHANGELOG and fix semantic-release config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# CHANGELOG
+
+All notable changes to this project will be documented in this file.
+
+This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+<!--next-version-placeholder-->

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,9 +106,10 @@ match = "main"
 prerelease = false
 
 [tool.semantic_release.changelog]
-template_dir = "templates"
-changelog_file = "CHANGELOG.md"
 exclude_commit_patterns = []
+
+[tool.semantic_release.changelog.default_templates]
+changelog_file = "CHANGELOG.md"
 
 [tool.semantic_release.changelog.environment]
 block_start_string = "{%"


### PR DESCRIPTION
## Problem

The release-pr workflow was failing with:

```
WARNING:root:[Errno 2] No such file or directory: 'CHANGELOG.md'
Error: some required outputs were not set: commit_sha
```

This prevented semantic-release from creating version bump commits.

## Root Causes

1. **Missing CHANGELOG.md**: semantic-release expected this file to exist but it didn't
2. **Invalid template_dir**: Config pointed to non-existent `templates/` directory
3. **Deprecated config format**: Using old `changelog.changelog_file` setting

## Solution

### Created Initial CHANGELOG.md
```markdown
# CHANGELOG

All notable changes to this project will be documented in this file.

This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

<!--next-version-placeholder-->
```

### Fixed semantic-release Configuration
- **Removed** `template_dir = "templates"` (non-existent directory)
- **Migrated** `changelog_file` to new location:
  ```toml
  [tool.semantic_release.changelog.default_templates]
  changelog_file = "CHANGELOG.md"
  ```

This addresses the deprecation warning:
```
WARNING: The 'changelog.changelog_file' configuration option is moving to 
'changelog.default_templates.changelog_file'
```

## Expected Behavior After Fix

semantic-release should now:
1. ✅ Find CHANGELOG.md
2. ✅ Use built-in templates (no custom template directory)
3. ✅ Create version bump commits successfully
4. ✅ Set commit_sha output properly
5. ✅ Create release PR with updated changelog

## Related

- Builds on PR #13 which disabled build during PR creation
- Part of the release automation workflow fixes