### PR TITLE
fix: add --skip-build flag to semantic-release version command

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -69,7 +69,7 @@ jobs:
           BRANCH_NAME="release-v${NEW_VERSION}"
 
           # Run semantic-release on main to create the version bump commits
-          uv run semantic-release version --no-push --no-tag
+          uv run semantic-release version --no-push --no-tag --skip-build
 
           # Create release branch from the current state (with version bump commits)
           git branch -f "$BRANCH_NAME"


### PR DESCRIPTION
## Problem

The release-pr workflow continues to fail with:

```
No build command specified, skipping
Error: some required outputs were not set: commit_sha
```

Even with `upload_to_release = true`, semantic-release was trying to run the build phase and failing before completing the commit phase.

## Root Cause

semantic-release's `version` command has these phases:
1. Update version files ✅
2. Generate changelog ✅
3. Create commits ⏸️ (where it's stopping)
4. Build project ❌ (failing here with no build command)
5. Set outputs ❌ (never reached)

The workflow was getting stuck at the build phase, preventing `commit_sha` from being set.

## Solution

Added `--skip-build` flag to the semantic-release version command:

```bash
uv run semantic-release version --no-push --no-tag --skip-build
```

This ensures:
1. ✅ Version files updated
2. ✅ Changelog generated
3. ✅ Commits created
4. ⏩ Build skipped (we don't need it during PR creation)
5. ✅ Outputs set properly

## Workflow Separation

**release-pr.yml** (this workflow):
- Updates versions and changelog
- Creates commits
- **Skips build** (using --skip-build)
- Creates PR

**release-publish.yml** (after PR merge):
- Builds package with `uv build`
- Publishes to PyPI
- Creates GitHub release with tag

## Related

- Builds on PR #15 which enabled upload_to_release
- Part of the complete release automation workflow fixes