### PR TITLE
fix: add --vcs-release flag to enable commit_sha output

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -69,7 +69,7 @@ jobs:
           BRANCH_NAME="release-v${NEW_VERSION}"
 
           # Run semantic-release on main to create the version bump commits
-          uv run semantic-release version --no-push --no-tag --skip-build
+          uv run semantic-release version --no-push --no-tag --skip-build --vcs-release
 
           # Create release branch from the current state (with version bump commits)
           git branch -f "$BRANCH_NAME"


### PR DESCRIPTION
## Problem

The workflow is now correctly skipping the build (thanks to PR #16), but still failing with:

```
Skipping build due to --skip-build flag
Error: some required outputs were not set: commit_sha
```

semantic-release is completing the version bump but not setting the `commit_sha` output.

## Root Cause

The `commit_sha` output appears to only be set when semantic-release attempts VCS release creation. Without this, the workflow exits before setting outputs.

## Solution

Added `--vcs-release` flag:

```bash
uv run semantic-release version --no-push --no-tag --skip-build --vcs-release
```

### Expected Behavior:
1. ✅ Creates version bump commits
2. ✅ Attempts VCS (GitHub) release creation
3. ⚠️ VCS release skipped (no tag exists due to --no-tag)
4. ✅ Sets `commit_sha` output from the version bump commit
5. ✅ Workflow completes successfully

The combination of `--vcs-release` (enable VCS operations) and `--no-tag` (skip tagging) should trigger the output setting while avoiding actual release creation.

## Related

- Builds on PR #16 which added --skip-build
- Part of the release automation workflow fixes