### PR TITLE
fix: use PAT to trigger CI workflows on release PRs

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -18,6 +18,10 @@ jobs:
         id: release
         with:
           release-type: python
+          # Use PAT instead of GITHUB_TOKEN to trigger CI workflows on release PRs
+          # GitHub's GITHUB_TOKEN doesn't trigger workflows to prevent recursion
+          # See: https://github.com/googleapis/release-please/issues/922
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
 
       # Publish to PyPI when a release is created
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

Fixes the issue where CI checks don't run on release-please automated PRs (like #21), which blocks merging due to branch protection rules.

## Root Cause

GitHub's `GITHUB_TOKEN` doesn't trigger workflows on PRs it creates to prevent recursive workflow runs. This is a security feature but means CI checks never run on release-please PRs.

## Solution

Use a Personal Access Token (PAT) instead of `GITHUB_TOKEN` in the release-please workflow. The PAT has permissions to trigger workflows on created PRs.

## References

- https://github.com/googleapis/release-please/issues/922

## Setup Required

After merging this PR, you'll need to create a repository secret:

1. Create a Personal Access Token with these permissions:
   - `contents: write`
   - `pull-requests: write`
2. Add it to repository secrets as `RELEASE_PLEASE_TOKEN`

Once configured, future release-please PRs will trigger all CI workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)