### PR TITLE
feat: use GitHub App for verified commits in release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,14 +14,21 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
+      # Generate GitHub App token for authenticated API requests
+      # GitHub App commits are automatically verified (signed by GitHub)
+      # Also triggers CI workflows on release PRs (unlike GITHUB_TOKEN)
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.RELEASE_PLEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PLEASE_PRIVATE_KEY }}
+
       - uses: googleapis/release-please-action@v4
         id: release
         with:
           release-type: python
-          # Use PAT instead of GITHUB_TOKEN to trigger CI workflows on release PRs
-          # GitHub's GITHUB_TOKEN doesn't trigger workflows to prevent recursion
-          # See: https://github.com/googleapis/release-please/issues/922
-          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       # Publish to PyPI when a release is created
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

Switches from Personal Access Token to GitHub App authentication for release-please, providing **verified commits** and triggering CI workflows.

## Benefits

### 1. Verified Commits ✅
GitHub **automatically verifies** commits made via GitHub App API requests. No GPG key management needed - release commits will show the verified badge.

### 2. Triggers CI Workflows ✅
Unlike `GITHUB_TOKEN`, GitHub App tokens trigger workflows on created PRs, so release PRs will have all CI checks running.

### 3. More Secure
GitHub Apps have scoped permissions and better audit trails than PATs.

## Changes

- Added `actions/create-github-app-token@v1` step to generate app token
- Updated `release-please-action` to use the GitHub App token
- Updated comments to explain benefits
- Removed PAT references (supersedes #22)

## Testing Plan

After merging:
1. Close existing release PR #21
2. Trigger a new release PR (push a `feat:` commit or manually trigger workflow)
3. Verify the release commit shows as "Verified"
4. Verify CI checks run on the release PR

## Setup Completed

✅ GitHub App created with required permissions
✅ App ID stored in `RELEASE_PLEASE_APP_ID` variable
✅ Private key stored in `RELEASE_PLEASE_PRIVATE_KEY` secret
✅ App installed on repository

🤖 Generated with [Claude Code](https://claude.com/claude-code)